### PR TITLE
Added Python3 compat info, tested with Python 2.7.18 and Python 3.8.6

### DIFF
--- a/octoprint_eeprom_repetier/__init__.py
+++ b/octoprint_eeprom_repetier/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 ### (Don't forget to remove me)
 # This is a basic skeleton for your plugin's __init__.py. You probably want to adjust the class name of your plugin
@@ -10,6 +10,8 @@ from __future__ import absolute_import
 
 import octoprint.plugin
 import octoprint.server
+
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 class Eeprom_repetierPlugin(octoprint.plugin.AssetPlugin,
                             octoprint.plugin.TemplatePlugin):
@@ -40,7 +42,7 @@ class Eeprom_repetierPlugin(octoprint.plugin.AssetPlugin,
             )
         )
 
-__plugin_name__ = "EEPROM Repetier Editor Plugin"
+__plugin_name__ = "EEPROM Editor - Repetier"
 
 def __plugin_load__():
     global __plugin_implementation__

--- a/octoprint_eeprom_repetier/static/js/eeprom_repetier.js
+++ b/octoprint_eeprom_repetier/static/js/eeprom_repetier.js
@@ -62,12 +62,12 @@ $(function() {
                             description: match[4]
                         });
                     }
-		    else if (line.includes("Info:Configuration stored to EEPROM")) {
-			self.showPopup("success", "Configuration stored to EEPROM.", "");
-		    }
-		    else if (line.includes("Info:Configuration reset to defaults")) {
-			self.showPopup("success", "Configuration reset to defaults.", "");
-		    }
+		            else if (line.includes("Info:Configuration stored to EEPROM")) {
+			            self.showPopup("success", "Configuration stored to EEPROM.", "");
+		            }
+		            else if (line.includes("Info:Configuration reset to defaults")) {
+			            self.showPopup("success", "Configuration reset to defaults.", "");
+                    }
                 });
             }
         };
@@ -148,10 +148,18 @@ $(function() {
             }
         };
     }
-
+/* Old style viewmodel declaration - deprecated
     OCTOPRINT_VIEWMODELS.push([
         EepromRepetierViewModel,
         ["controlViewModel", "connectionViewModel"],
         "#settings_plugin_eeprom_repetier"
     ]);
+*/
+    OCTOPRINT_VIEWMODELS.push({
+        construct: EepromRepetierViewModel,
+        additionalNames: [],
+        dependencies: ["controlViewModel", "connectionViewModel"],
+        optional: [],
+        elements: ["#settings_plugin_eeprom_repetier"]
+    });
 });

--- a/octoprint_eeprom_repetier/templates/eeprom_repetier_settings.jinja2
+++ b/octoprint_eeprom_repetier/templates/eeprom_repetier_settings.jinja2
@@ -1,15 +1,18 @@
-<h4>EEprom Repetier Plugin</h4>
-This plugin is designed to get, change and save the values in the Eeprom of your Repetier Firmware based Machine.<br>
-Your machine is <span style="color: red" data-bind="visible: isConnected() && !isRepetierFirmware()">not</span> Repetier Firmware based
+<div style="height: 95%; overflow: hidden; display: block; position: absolute;">
+<h3>EEPROM Editor for Repetier</h3>
+This allows you to get, change and save the values in the EEPROM of your Repetier Firmware based Machine.<br>
+<span style data-bind="visible: !isConnected()">Your printer is <span style="color: red">not</span> connected.<br></span>
+<span style data-bind="visible: isConnected()">Your machine is <span style="color: red" data-bind="visible: !isRepetierFirmware()">not</span> Repetier Firmware based.
+</span>
 </>
 
-<form class="form-horizontal">
-    <button class="btn" data-bind="enabled: isRepetierFirmware, click: loadEeprom">{{ _('Load EEprom') }}</button>
-    <button class="btn" data-bind="enabled: isRepetierFirmware, click: saveEeprom">{{ _('Save EEprom') }}</button>
-    <button class="btn" data-bind="enabled: isRepetierFirmware, click: resetEeprom">{{ _('Reset EEprom') }}</button>
+<form class="form-horizontal" data-bind="visible: isConnected() && isRepetierFirmware()">
+    <button class="btn" title="Load the current EEPROM values" data-bind="enable: isRepetierFirmware(), click: loadEeprom">{{ _('Load EEPROM') }}</button>
+    <button class="btn" title="Save any changes back to the EEPROM" data-bind="enable: (isRepetierFirmware() && eepromData().length > 0), click: saveEeprom">{{ _('Save EEPROM') }}</button>
+    <button class="btn" title="Set the EEPROM values to the config defaults and activate them" data-bind="enable: isRepetierFirmware(), click: resetEeprom">{{ _('Reset EEPROM') }}</button>
 </form>
 
-<div data-bind="foreach: eepromData">
+<div data-bind="foreach: eepromData" style="overflow-y: auto; height: 70%;">
     <form class="form-horizontal">
         <div class="control-group">
             <label class="control-label" style="width: 300px" data-bind="text: description, attr: { 'for': position }"></label>
@@ -18,4 +21,5 @@ Your machine is <span style="color: red" data-bind="visible: isConnected() && !i
             </div>
         </div>
     </form>
+</div>
 </div>

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-
+from __future__ import absolute_import, unicode_literals
 ########################################################################################################################
 ### Do not forget to adjust the following variables to your own plugin.
 
@@ -14,7 +14,7 @@ plugin_package = "octoprint_eeprom_repetier"
 plugin_name = "OctoPrint-EEprom-Repetier"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.2"
+plugin_version = "0.1.3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Hi - this is in response to the issue raised requesting Python 3 compatibility.  As the plugin only comprises a few files, I have merged in content from an earlier pull request to add a scrolling region for the eeprom data.  I think this improves usability.  I also reviewed the rest of the code and made other updates as listed below.  Hope this saves time and effort for you.  

The updates have been tested on a live Repetier v1.0.4 firmware based printer to verify operation.  Tested with Windows-based host and OctoPi. 

Summary of changes:

- Updated internal version number to 0.1.3.
- Replaced deprecated ViewModel declaration with newer syntax.
- Adjusted .js indentation to improve code legibility.
- Incorporated bounded scrolling section for EEPROM values so that buttons remain visible at top of form.
- Changed visibility logic of buttons so they only appear when a valid print is connected.
- Fixed syntax of the data-bind:enable on buttons.
- Changed enable state of "Save to EEPROM" button -- only enabled when data is loaded.
- Added tooltips on buttons.