### PR TITLE
Unicode imports removed from Setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_eeprom_repetier"
 plugin_name = "OctoPrint-EEprom-Repetier"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.5"
+plugin_version = "0.1.6"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import, unicode_literals
+
 ########################################################################################################################
 ### Do not forget to adjust the following variables to your own plugin.
 


### PR DESCRIPTION
Fix for issue #16. The import unicode_literals in Setup.py can cause an error with older versions of the setuptools for pip2.  This import is not required for correct operation in Python 2.7 or 3.x and has been removed.  